### PR TITLE
Fix Future<Image> and Image inconsistency

### DIFF
--- a/lib/src/qr_painter.dart
+++ b/lib/src/qr_painter.dart
@@ -97,7 +97,7 @@ class QrPainter extends CustomPainter {
 
   Future<ByteData> toImageData(double size,
       {ui.ImageByteFormat format = ui.ImageByteFormat.png}) async {
-    final ui.Image uiImage =
+    final ui.Image uiImage = await
         toPicture(size).toImage(size.toInt(), size.toInt());
     return await uiImage.toByteData(format: format);
   }


### PR DESCRIPTION
The build failed because Future<Image> cannot be assigned to Image, and toImage() is asynchronous. Adding await makes this part synchronous, and makes the project build properly.