### PR TITLE
fix image paint in flutter 2.x and 1.x (backward compatibility)

### DIFF
--- a/lib/src/qr_painter.dart
+++ b/lib/src/qr_painter.dart
@@ -97,8 +97,10 @@ class QrPainter extends CustomPainter {
 
   Future<ByteData> toImageData(double size,
       {ui.ImageByteFormat format = ui.ImageByteFormat.png}) async {
-    final ui.Image uiImage =
-        toPicture(size).toImage(size.toInt(), size.toInt());
-    return await uiImage.toByteData(format: format);
+    final Object uiImage =
+    toPicture(size).toImage(size.toInt(), size.toInt());
+    final ui.Image imageFinal  = (uiImage is Future<ui.Image>) ? await uiImage : uiImage;
+    
+    return await imageFinal.toByteData(format: format);
   }
 }


### PR DESCRIPTION
This code, unlike what is implemented in the development version, allows backward compatibility between the old version of the flutter and the new one, this will avoid a lot of problems and also allow the new version of the code in development to be compatible with the old version of the flutter. 

Kindly reconsider and appreciate if it would be interesting to add this to the project.