### PR TITLE
Fix TypeError in lib/src/qr_painter.dart

### DIFF
--- a/lib/src/qr_painter.dart
+++ b/lib/src/qr_painter.dart
@@ -98,7 +98,7 @@ class QrPainter extends CustomPainter {
   Future<ByteData> toImageData(double size,
       {ui.ImageByteFormat format = ui.ImageByteFormat.png}) async {
     final ui.Image uiImage =
-        toPicture(size).toImage(size.toInt(), size.toInt());
+        await toPicture(size).toImage(size.toInt(), size.toInt());
     return await uiImage.toByteData(format: format);
   }
 }


### PR DESCRIPTION
Fixes this issue from the Pub page (which also breaks any app depending on it):

```
Fix lib/src/qr_painter.dart. (-25 points)

Analysis of lib/src/qr_painter.dart failed with 1 error:

line 101 col 9: A value of type 'Future<Image>' can't be assigned to a variable of type 'Image'.
```

There was just a missing `await`.