### PR TITLE
add rawBytes content support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.2.1
+- add Qr from rawBytes support
+
 # 3.2.0
 - Fix issue where finder patterns don't render correctly with the painter
 - Small fixes + optimizations

--- a/lib/src/qr_image.dart
+++ b/lib/src/qr_image.dart
@@ -5,6 +5,7 @@
  */
 
 import 'dart:async';
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
@@ -35,8 +36,10 @@ class QrImage extends StatefulWidget {
     this.embeddedImage,
     this.embeddedImageStyle,
     this.embeddedImageEmitsError = false,
+    Uint8List rawBytes,
   })  : assert(QrVersions.isSupportedVersion(version)),
         _data = data,
+        _rawBytes = rawBytes,
         _qrCode = null,
         super(key: key);
 
@@ -59,11 +62,13 @@ class QrImage extends StatefulWidget {
     this.embeddedImageEmitsError = false,
   })  : assert(QrVersions.isSupportedVersion(version)),
         _data = null,
+        _rawBytes = null,
         _qrCode = qr,
         super(key: key);
 
   // The data passed to the widget
   final String _data;
+  final Uint8List _rawBytes;
   // The QR code data passed to the widget
   final QrCode _qrCode;
 
@@ -134,6 +139,7 @@ class _QrImageState extends State<QrImage> {
         data: widget._data,
         version: widget.version,
         errorCorrectionLevel: widget.errorCorrectionLevel,
+        rawBytes: widget._rawBytes,
       );
       if (_validationResult.isValid) {
         _qr = _validationResult.qrCode;

--- a/lib/src/qr_painter.dart
+++ b/lib/src/qr_painter.dart
@@ -38,8 +38,9 @@ class QrPainter extends CustomPainter {
     this.gapless = false,
     this.embeddedImage,
     this.embeddedImageStyle,
+    Uint8List rawBytes,
   }) : assert(QrVersions.isSupportedVersion(version)) {
-    _init(data);
+    _init(data, rawBytes: rawBytes);
   }
 
   /// Create a new QrPainter with a pre-validated/created [QrCode] object. This
@@ -96,7 +97,7 @@ class QrPainter extends CustomPainter {
   /// Cache for all of the [Paint] objects.
   final _paintCache = PaintCache();
 
-  void _init(String data) {
+  void _init(String data, {Uint8List rawBytes}) {
     if (!QrVersions.isSupportedVersion(version)) {
       throw QrUnsupportedVersionException(version);
     }
@@ -105,6 +106,7 @@ class QrPainter extends CustomPainter {
       data: data,
       version: version,
       errorCorrectionLevel: errorCorrectionLevel,
+      rawBytes: rawBytes,
     );
     if (!validationResult.isValid) {
       throw validationResult.error;

--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -4,6 +4,8 @@
  * See LICENSE for distribution and usage details.
  */
 
+import 'dart:typed_data';
+
 import 'package:flutter/foundation.dart';
 import 'package:qr/qr.dart';
 
@@ -18,6 +20,7 @@ class QrValidator {
     @required String data,
     int version = QrVersions.auto,
     int errorCorrectionLevel = QrErrorCorrectLevel.L,
+    Uint8List rawBytes,
   }) {
     QrCode qrCode;
     try {
@@ -25,10 +28,15 @@ class QrValidator {
         qrCode = QrCode(version, errorCorrectionLevel);
         qrCode.addData(data);
       } else {
-        qrCode = QrCode.fromData(
-          data: data,
-          errorCorrectLevel: errorCorrectionLevel,
-        );
+        qrCode = rawBytes != null
+            ? QrCode.fromUint8List(
+                data: rawBytes,
+                errorCorrectLevel: errorCorrectionLevel,
+              )
+            : QrCode.fromData(
+                data: data,
+                errorCorrectLevel: errorCorrectionLevel,
+              );
       }
       qrCode.make();
       return QrValidationResult(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: qr_flutter
 description: >
   QR.Flutter is a Flutter library for simple and fast QR code rendering via a
   Widget or custom painter.
-version: 3.2.0
+version: 3.2.1
 homepage: https://github.com/lukef/qr.flutter
 
 environment:
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  qr: ^1.2.0
+  qr: ^1.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Hi this is an awesome project!
In our flutter App we need to use `bytes` data in Qr like this: [QR content for offline signature is not String](https://github.com/polkadot-js/apps/issues/2906).
So I did some modification and upgraded qr.dart  to `^1.3.0` to support rawBytes content.
