### PR TITLE
chore: remove unnecessary debug print

### DIFF
--- a/lib/src/qr_image_view.dart
+++ b/lib/src/qr_image_view.dart
@@ -202,7 +202,6 @@ class _QrImageViewState extends State<QrImageView> {
                     : _qrWidget(null, widgetSize);
               }
               if (snapshot.hasData) {
-                debugPrint('loaded image');
                 final loadedImage = snapshot.data;
                 return _qrWidget(loadedImage, widgetSize);
               } else {


### PR DESCRIPTION
remove unnecessary debug prints because when rebuilt, they are printed and become annoying.